### PR TITLE
Added readme info on what to do when one is unable to get to UEFI settings afterwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This should theoretically work in any AMD computer, however I have **only** test
 - Laptop model: Acer Swift 3 SF314-43
 - Firmware version: [1.06](https://global-download.acer.com/GDFiles/BIOS/BIOS/BIOS_Acer_1.06_A_A.zip?acerid=637998440494605648)&nbsp;(2022-09-27, "Support Win11 SV2")
 
+
+- Laptop model: Acer Swift SF314-42
+- Firmware version: 1.08
 ## Be aware!
 
 - If your system does not match **exactly** the requirements described above, I don't know what will happen and you **may brick your computer**.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ Now your laptop can enjoy a good night of S3 sleep!
 
 ## Known issues
 
-None so far.
+- Cannot access UEFI settings in SF314-42
+  - Boot into the USB again
+  - Go to ``BootManager``
+  - Select Delete option
+  - Select all the ``UEFI-Misc-*`` options
+  - Delete all those, make sure you are not touching other enteries
+  - Save the changes and select Continue
 
 ## FAQs
 


### PR DESCRIPTION
Also that I can confirm this works in Acer Swift SF314-42 with UEFI version 1.08